### PR TITLE
Add missing `percentPlayed` field to `onPlayBackEnded` events

### DIFF
--- a/resources/lib/events.py
+++ b/resources/lib/events.py
@@ -42,7 +42,7 @@ class Events(object):
                         'episode', 'showtitle', 'percentPlayed'],
             'varArgs': {'%mt': 'mediaType', '%fn': 'fileName', '%ti': 'title', '%ar': 'aspectRatio', '%ht': 'height',
                         '%wi': 'width', '%sm': 'stereomode', '%se': 'season', '%ep': 'episode', '%st': 'showtitle',
-                        '%at': 'artist', '%al': 'album'},
+                        '%at': 'artist', '%al': 'album', '%pp': 'percentPlayed'},
             'expArgs': {'mediaType': 'movie', 'fileName': 'G:\\movies\\Star Wars - Episode IV\\movie.mkv',
                         'title': 'Star Wars Episode IV - A New Hope', 'percentPlayed': '26'}
         },


### PR DESCRIPTION
The `onPlayBackEnded` needed to specify that `percentPlayed` was a valid
substitution field.

The event allows for (and even provides in the example) a field for `percentPlayed`:
https://github.com/KenV99/script.service.kodi.callbacks/blob/d5dfb0ec3555c64dcf173ca5f8422add8e6970af/resources/lib/events.py#L43-L47
yet, this field is never substituted in args.

I used `%pp` as the two-letter field name despite there already being another `%pp` for `profilePath`. These two fields should never collide, so I figured it was okay to do this. 

