### PR TITLE
Fix onPlayBackStarted event

### DIFF
--- a/resources/lib/events.py
+++ b/resources/lib/events.py
@@ -24,7 +24,7 @@ def requires_subtopic():
 
 class Events(object):
     Player = {
-        'onPlayBackStarted': {
+        'onAVStarted': {
             'text': 'on Playback Started',
             'reqInfo': [],
             'optArgs': ['mediaType', 'fileName', 'title', 'aspectRatio', 'width', 'height', 'stereomode', 'season',

--- a/resources/lib/publishers/player.py
+++ b/resources/lib/publishers/player.py
@@ -327,7 +327,7 @@ class Player(xbmc.Player):
             vr = u'unknown'
         return str(vr)
 
-    def onPlayBackStarted(self):
+    def onAVStarted(self):
         self.getInfo()
         try:
             self.totalTime = self.getTotalTime()
@@ -336,7 +336,7 @@ class Player(xbmc.Player):
         finally:
             if self.totalTime == 0:
                 self.totalTime = -1
-        topic = Topic('onPlayBackStarted')
+        topic = Topic('onAVStarted')
         self.publish(Message(topic, **self.info))
 
     def onPlayBackEnded(self):


### PR DESCRIPTION
Hi there,
Thanks to https://github.com/KenV99/script.service.kodi.callbacks/issues/6#issuecomment-534526259 I fixed the `onPlayBackStarted` event, replacing it with `onAVStarted`.
I didn't changed the user `on playback started` message because I think this is easier to understand but it might be confusing with the Kodi API so maybe I should add an event instead of replacing the old one.
Let me know.
Have a nice day.