### PR TITLE
Fixed an IndexError from breaking callbacks.

### DIFF
--- a/resources/lib/publishers/player.py
+++ b/resources/lib/publishers/player.py
@@ -266,7 +266,7 @@ class Player(xbmc.Player):
             try:
                 playerid = player['result'][0]['playerid']
                 playertype = player['result'][0]['type']
-            except KeyError:
+            except (KeyError, IndexError):
                 playerid = -1
                 playertype = 'none'
         if playertype == 'audio':


### PR DESCRIPTION
I was getting this:

2020-05-13 23:31:05.726 T:1437594336   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.IndexError'>
                                            Error Contents: list index out of range
                                            Traceback (most recent call last):
                                              File "/home/osmc/.kodi/addons/script.service.kodi.callbacks/resources/lib/publishers/player.py", line 331, in onPlayBackStarted
                                                self.getInfo()
                                              File "/home/osmc/.kodi/addons/script.service.kodi.callbacks/resources/lib/publishers/player.py", line 267, in getInfo
                                                playerid = player['result'][0]['playerid']
                                            IndexError: list index out of range
                                            -->End of Python script error report<--